### PR TITLE
Fixed minor bug in PredictRecommender.recommend()

### DIFF
--- a/reclab/recommenders/recommender.py
+++ b/reclab/recommenders/recommender.py
@@ -237,13 +237,14 @@ class PredictRecommender(Recommender):
 
         # Pick items according to the strategy, along with their predicted ratings.
         all_recs = []
-        predicted_ratings = []
+        all_predicted_ratings = []
         for item_ids, predictions in zip(all_item_ids, all_predictions):
             recs, predicted_ratings = self._select_item(item_ids, predictions,
                                                         num_recommendations)
             # Convert the recommendations to outer item ids.
             all_recs.append([self._inner_to_outer_iid[rec] for rec in recs])
-        return np.array(all_recs), np.array(predicted_ratings)
+            all_predicted_ratings.append(predicted_ratings)
+        return np.array(all_recs), np.array(all_predicted_ratings)
 
     def predict(self, user_item):
         """Predict the ratings of user-item pairs.


### PR DESCRIPTION
There was an issue that the method only returned the predicted ratings corresponding to the last user in iteration of the loop as opposed to appending them together.

Minor change to fix this.