### PR TITLE
Add support for MCMC and ALS in libfm

### DIFF
--- a/reclab/recommenders/libfm.py
+++ b/reclab/recommenders/libfm.py
@@ -190,7 +190,10 @@ class LibFM(recommender.PredictRecommender):
                                               shape=(len(user_item), self._num_features))
         test_data = wpyfm.Data(test_inputs, np.zeros(test_inputs.shape[0]), has_xt=self._has_xt)
 
-        self._model.train(self._train_data)
+        if self._has_xt:
+            self._model.train(self._train_data, test=test_data)
+        else:
+            self._model.train(self._train_data)
         predictions = self._model.predict(test_data)
 
         return predictions

--- a/tests/test_libfm.py
+++ b/tests/test_libfm.py
@@ -34,3 +34,60 @@ def test_sgd_recommend():
                         num_iter=128,
                         seed=0)
     utils.test_recommend_simple(recommender)
+
+
+def test_mcmc_predict():
+    """Test that LibFM trained with MCMC predicts well and that it gets better with more data."""
+    recommender = LibFM(num_user_features=0,
+                        num_item_features=0,
+                        num_rating_features=0,
+                        max_num_users=utils.NUM_USERS_ML100K,
+                        max_num_items=utils.NUM_ITEMS_ML100K,
+                        method='mcmc',
+                        num_two_way_factors=8,
+                        num_iter=128,
+                        seed=0)
+    utils.test_predict_ml100k(recommender, rmse_threshold=1.1)
+
+
+def test_mcmc_recommend():
+    """Test that LibFM trained with MCMC will recommend reasonable items."""
+    recommender = LibFM(num_user_features=0,
+                        num_item_features=0,
+                        num_rating_features=0,
+                        max_num_users=utils.NUM_USERS_SIMPLE,
+                        max_num_items=utils.NUM_ITEMS_SIMPLE,
+                        method='mcmc',
+                        num_two_way_factors=8,
+                        num_iter=128,
+                        seed=0)
+    utils.test_recommend_simple(recommender)
+
+
+def test_als_predict():
+    """Test that LibFM trained with ALS predicts well and that it gets better with more data."""
+    recommender = LibFM(num_user_features=0,
+                        num_item_features=0,
+                        num_rating_features=0,
+                        max_num_users=utils.NUM_USERS_ML100K,
+                        max_num_items=utils.NUM_ITEMS_ML100K,
+                        method='als',
+                        num_two_way_factors=8,
+                        reg=0.02,
+                        num_iter=128,
+                        seed=0)
+    utils.test_predict_ml100k(recommender, rmse_threshold=1.3)
+
+
+def test_als_recommend():
+    """Test that LibFM trained with ALS will recommend reasonable items."""
+    recommender = LibFM(num_user_features=0,
+                        num_item_features=0,
+                        num_rating_features=0,
+                        max_num_users=utils.NUM_USERS_SIMPLE,
+                        max_num_items=utils.NUM_ITEMS_SIMPLE,
+                        method='als',
+                        num_two_way_factors=8,
+                        num_iter=128,
+                        seed=0)
+    utils.test_recommend_simple(recommender)


### PR DESCRIPTION
This pull request allows libfm to use its MCMC and ALS methods. Note that ALS performed particularly poorly in the ML100K test and I had to increase the RMSE threshold. I'm not sure if this is a result of my poor tuning or because ALS just isn't well suited to the ML100K dataset.