### PR TITLE
Update the tensorflow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ sklearn==0.0
 snowballstemmer==2.0.0
 tensorboard==2.2.2
 tensorboard-plugin-wit==1.7.0
-tensorflow==2.2.1
+tensorflow>=2.2.1
 tensorflow-estimator==2.2.0
 termcolor==1.1.0
 threadpoolctl==2.1.0


### PR DESCRIPTION
Currently travis builds fail on osx due to an unavailable tensorflow version. This pull request fixes this.